### PR TITLE
encoding fix to get alljavadoc task to succeed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ task fixCodeBlock(type: FixJavadocCodeBlockTask) {
 }
 
 task alljavadoc(type: Javadoc) {
+	options.encoding = 'UTF-8'
 	def jeneticsProjects = subprojects.findAll { project ->
 		project.name.startsWith('org.jeneti') &&
 		project.name != 'org.jenetics.doc'

--- a/org.jenetics/src/main/java/org/jenetics/internal/util/require.java
+++ b/org.jenetics/src/main/java/org/jenetics/internal/util/require.java
@@ -99,7 +99,7 @@ public final class require {
 	}
 
 	/**
-	 * Require the given {@code value} to be positive (&gt: 0).
+	 * Require the given {@code value} to be positive (&gt; 0).
 	 * @param value the value to check
 	 * @return the given value
 	 * @throws IllegalArgumentException if the given {@code value} is smaller than


### PR DESCRIPTION
I just wanted to generate the javadocs, but the gradle task was failing. Turns out the fix was simple.