### PR TITLE
#420: Fix 'FitnessThresholdLimit' termination strategy.

### DIFF
--- a/jenetics/src/main/java/io/jenetics/engine/FitnessThresholdLimit.java
+++ b/jenetics/src/main/java/io/jenetics/engine/FitnessThresholdLimit.java
@@ -34,15 +34,23 @@ final class FitnessThresholdLimit<C extends Comparable<? super C>>
 
 	private final C _threshold;
 
+	private boolean _proceed = true;
+
 	FitnessThresholdLimit(final C threshold) {
 		_threshold = requireNonNull(threshold);
 	}
 
 	@Override
 	public boolean test(final EvolutionResult<?, C> result) {
-		return result.getTotalGenerations() <= 1 ||
-			result.getOptimize()
-				.compare(_threshold, result.getBestFitness()) >= 0;
+		final boolean proceed =
+			_proceed &&
+			result.getOptimize().compare(_threshold, result.getBestFitness()) >= 0;
+
+		try {
+			return _proceed;
+		} finally {
+			_proceed = proceed;
+		}
 	}
 
 }


### PR DESCRIPTION
The generation which triggered the evolution stream truncation, was not part of the evolution stream. So the best found solution was missing the the evolution result.