### PR TITLE
Updated description of the mapping codec

### DIFF
--- a/jenetics.doc/src/main/lyx/manual.lyx
+++ b/jenetics.doc/src/main/lyx/manual.lyx
@@ -18412,7 +18412,8 @@ Assignment problem
 \begin_layout Standard
 This codec is a variation of the permutation codec.
  Instead of permuting the elements of a given array, it permutes the mapping
- of elements of a source set to the elements of a target set.
+ of elements of a source set to the elements of a target set. 
+ Note that the mapping is identical for all individuals whose first chromosome (only) is identical.
  The code snippet below shows the method of the 
 \family typewriter
 Codecs


### PR DESCRIPTION
Hi Franz and all the other contributers,
thank you for your hard - and brilliant - work on this library and the documentation.

After some experimentation, research and source code analysis I found that the mapping codec produces the same output for all individuals that share the same ~~genome~~ _genotype_ - but only with regard to their very first chromosome. This might be unexpected when multiple chromosomes are used. 

I suggest adding above line to the documentation.

Please let me know what you think.

Greetings and thanks again,
T.