### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,14 +13,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        java-version: [ 11.0.3, 11, 17.0.1, 17, 18-ea  ]
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 17
+    - name: Set up JDK ${{ matrix.java-version }} on ${{ matrix.os }}
       uses: actions/setup-java@v2
       with:
-        java-version: '17'
-        distribution: 'adopt'
+        java-version: ${{ matrix.java-version }}
+        distribution: 'zulu'
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.

Please see more details at Foojay.io:
https://foojay.io/today/github-actions-with-java-part-2/

I hope you don't mind but I added additional fixed versions. Often a users machine might be at a lower version such as 11, or 17.0.1 as opposed to the latest and greatest build (11, or 17).

Building on Linux and MacOS:
- 11.0.3
- 11 (LTS latest)
- 17.0.1 
- 17 (LTS latest)
- 18-ea (early access release)