### PR TITLE
Restore AltererResult constructor

### DIFF
--- a/jenetics/src/main/java/io/jenetics/Alterer.java
+++ b/jenetics/src/main/java/io/jenetics/Alterer.java
@@ -113,7 +113,7 @@ public interface Alterer<
 	static <G extends Gene<?, G>, C extends Comparable<? super C>>
 	Alterer<G, C> of(final Alterer<G, C>... alterers) {
 		return alterers.length == 0
-			? (p, g) -> new AltererResult<>(p.asISeq(), 0)
+			? (p, g) -> new AltererResult<>(p.asISeq())
 			: alterers.length == 1
 				? alterers[0]
 				: new CompositeAlterer<>(ISeq.of(alterers));

--- a/jenetics/src/main/java/io/jenetics/AltererResult.java
+++ b/jenetics/src/main/java/io/jenetics/AltererResult.java
@@ -69,4 +69,14 @@ public final record AltererResult<
 		requireNonNull(population);
 	}
 
+	/**
+	 * Create a new alter result for the given population with zero alterations.
+	 *
+	 * @param population the altered population
+	 * @throws NullPointerException if the given population is {@code null}
+	 */
+	public AltererResult(ISeq<Phenotype<G, C>> population) {
+		this(population, 0);
+	}
+
 }

--- a/jenetics/src/main/java/io/jenetics/CompositeAlterer.java
+++ b/jenetics/src/main/java/io/jenetics/CompositeAlterer.java
@@ -73,7 +73,7 @@ final class CompositeAlterer<
 		final Seq<Phenotype<G, C>> population,
 		final long generation
 	) {
-		AltererResult<G, C> result = new AltererResult<>(population.asISeq(), 0);
+		AltererResult<G, C> result = new AltererResult<>(population.asISeq());
 		for (var alterer : _alterers) {
 			final AltererResult<G, C> as = alterer.alter(
 				result.population(),

--- a/jenetics/src/main/java/io/jenetics/PartialAlterer.java
+++ b/jenetics/src/main/java/io/jenetics/PartialAlterer.java
@@ -99,7 +99,7 @@ public final class PartialAlterer<
 				result.alterations()
 			);
 		} else {
-			return new AltererResult<>(population.asISeq(), 0);
+			return new AltererResult<>(population.asISeq());
 		}
 	}
 

--- a/jenetics/src/main/java/io/jenetics/Recombinator.java
+++ b/jenetics/src/main/java/io/jenetics/Recombinator.java
@@ -110,7 +110,7 @@ public abstract class Recombinator<
 
 			result = new AltererResult<>(pop.toISeq(), count);
 		} else {
-			result = new AltererResult<>(population.asISeq(), 0);
+			result = new AltererResult<>(population.asISeq());
 		}
 
 		return result;

--- a/jenetics/src/test/java/io/jenetics/PartialAltererTest.java
+++ b/jenetics/src/test/java/io/jenetics/PartialAltererTest.java
@@ -149,7 +149,7 @@ public class PartialAltererTest {
 			.collect(ISeq.toISeq());
 
 		final Alterer<DoubleGene, Double> alterer = PartialAlterer.of(
-			(pop, gen) -> new AltererResult<>(pop.asISeq(), 0),
+			(pop, gen) -> new AltererResult<>(pop.asISeq()),
 			1, 2
 		);
 


### PR DESCRIPTION
As part of #632, 79022958bafaf94d115355f505793ee91cdd1f22 converted `AltererResult` into a record. Thereby the alternative constructor _without_ `alterations` (default of zero) has been removed.


Personally, I find this alternative constructor quite useful. Also the Jenetics soure code was using it in several places. This PR restores the constructor and its usage.