### PR TITLE
Parameterize example Engine.Builder<>

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,12 @@ The previous image shows the GUI after evolving the default image for about 4,00
 
 <details>
 <summary>
-Guilherme Espada, Leon Ingelse, Paulo Canelas, Pedro Barbosa, Alcides Fonseca. <a href="https://arxiv.org/abs/2210.04826">Data types as a more ergonomic frontend for Grammar-Guided Genetic Programming.</a> <em> arXiv. </em> Oct. 2022.
+Ricardo Ferreira Vilela, João Choma Neto, Victor Hugo Santiago Costa Pinto, Paulo Sérgio Lopes de Souza, Simone do Rocio Senger de Souza. <a href="https://doi.org/10.1002/cpe.7489">Bio-inspired optimization to support the test data generation of concurrent software.</a> <em> Concurrency and Computation: Practice and Experience. </em> Nov. 2022.
 
 ...
 </summary>
 
+1) Ricardo Ferreira Vilela, João Choma Neto, Victor Hugo Santiago Costa Pinto, Paulo Sérgio Lopes de Souza, Simone do Rocio Senger de Souza. <a href="https://doi.org/10.1002/cpe.7489">Bio-inspired optimization to support the test data generation of concurrent software.</a> <em> Concurrency and Computation: Practice and Experience. </em> Nov. 2022.
 1) Guilherme Espada, Leon Ingelse, Paulo Canelas, Pedro Barbosa, Alcides Fonseca. <a href="https://arxiv.org/abs/2210.04826">Data types as a more ergonomic frontend for Grammar-Guided Genetic Programming.</a> <em> arXiv. </em> Oct. 2022.
 1) Christoph G. Schuetz, Thomas Lorünser, Samuel Jaburek, Kevin Schuetz, Florian Wohner, Roman Karl & Eduard Gringinger. <a href="https://doi.org/10.1007/978-3-031-17834-4_10">A Distributed Architecture for Privacy-Preserving Optimization Using Genetic Algorithms and Multi-party Computation.</a> <em> CoopIS 2022: Cooperative Information Systems pp 168–185. </em> Sep. 2022.
 1) Christina Plump, Bernhard J. Berger, Rolf Drechsler. <a href="https://www.informatik.uni-bremen.de/agra/doc/konf/cec2022_cp.pdf">Using density of training data to improve evolutionary algorithms with approximative fitness functions.</a> <em> WCCI2022 IEEE WORLD CONGRESS ON COMPUTATIONAL INTELLIGENCE. </em> July 2022.

--- a/jenetics/src/main/java/io/jenetics/engine/Evaluator.java
+++ b/jenetics/src/main/java/io/jenetics/engine/Evaluator.java
@@ -41,7 +41,7 @@ import io.jenetics.util.Seq;
  *     .map(pt -> pt.eval(fitness))
  *     .asISeq();
  *
- * final Engine<G, C> engine = new Engine.Builder(evaluator, genotypeFactory)
+ * final Engine<G, C> engine = new Engine.Builder<>(evaluator, genotypeFactory)
  *     .build();
  * }</pre>
  *


### PR DESCRIPTION
Implementing the example as shown gives the error: "Type safety: The expression of type Engine needs unchecked conversion to conform to Engine<BitGene,Integer>" I have added type inference so as to not use the raw class.