### PR TITLE
Improve stochastic universal selector

### DIFF
--- a/jenetics/src/main/java/io/jenetics/StochasticUniversalSelector.java
+++ b/jenetics/src/main/java/io/jenetics/StochasticUniversalSelector.java
@@ -56,7 +56,7 @@ public class StochasticUniversalSelector<
 {
 
 	public StochasticUniversalSelector() {
-		super(true);
+		super(false);
 	}
 
 	/**
@@ -83,30 +83,26 @@ public class StochasticUniversalSelector<
 
 		final MSeq<Phenotype<G, N>> selection = MSeq.ofLength(count);
 
-		final Seq<Phenotype<G, N>> pop = _sorted
-			? population.asISeq().copy().sort(POPULATION_COMPARATOR)
-			: population;
-
-		final double[] probabilities = probabilities(pop, count, opt);
-		assert pop.size() == probabilities.length;
+		final double[] probabilities = probabilities(population, count, opt);
+		assert population.size() == probabilities.length;
 
 		//Calculating the equal spaces random points.
 		final double delta = 1.0/count;
 		final double[] points = new double[count];
 		points[0] = RandomRegistry.random().nextDouble()*delta;
 		for (int i = 1; i < count; ++i) {
-			points[i] = delta*i;
+			points[i] = points[i - 1] + delta;
 		}
 
 		int j = 0;
-		double prop = 0;
+		double cumProb = probabilities[0];
 		for (int i = 0; i < count; ++i) {
-			while (points[i] > prop) {
-				prop += probabilities[j];
+			while (points[i] > cumProb) {
 				++j;
+				cumProb += probabilities[j%population.size()];
 			}
 
-			selection.set(i, pop.get(j%pop.size()));
+			selection.set(i, population.get(j%population.size()));
 		}
 
 		return selection.toISeq();

--- a/jenetics/src/test/java/io/jenetics/StochasticUniversalSelectorTest.java
+++ b/jenetics/src/test/java/io/jenetics/StochasticUniversalSelectorTest.java
@@ -19,24 +19,25 @@
  */
 package io.jenetics;
 
-import static io.jenetics.incubator.stat.Assurance.assertThatObservation;
-import static io.jenetics.util.RandomRegistry.using;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
 import io.jenetics.incubator.stat.EmpiricalDistribution;
 import io.jenetics.internal.util.Named;
+import io.jenetics.util.DoubleRange;
 import io.jenetics.util.Factory;
 import io.jenetics.util.ISeq;
 import io.jenetics.util.StableRandomExecutor;
 import io.jenetics.util.TestData;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static io.jenetics.incubator.stat.Assurance.assertThatObservation;
+import static io.jenetics.util.RandomRegistry.using;
 
 /**
  * @author <a href="mailto:franz.wilhelmstoetter@gmail.com">Franz Wilhelmstötter</a>
@@ -47,7 +48,7 @@ public class StochasticUniversalSelectorTest
 
 	@Override
 	protected boolean isSorted() {
-		return true;
+		return false;
 	}
 
 	@Override
@@ -78,6 +79,32 @@ public class StochasticUniversalSelectorTest
 
 		final ISeq<Phenotype<IntegerGene, Integer>> selection =
 			selector.select(population, 50, Optimize.MINIMUM);
+	}
+
+	@Test
+	public void selectExpectedPopulation() {
+		final ISeq<Phenotype<DoubleGene, Double>> population =
+			ISeq.of(0.7, 0.2, 0.1)
+				.map(value ->
+					Phenotype.of(
+						Genotype.of(
+							DoubleChromosome.of(DoubleRange.of(0, 1), 1)
+						),
+						50,
+						value
+					)
+				);
+
+		// gives double equal to 1 on the first resolve
+		final Random random = new Random(43328395);
+		using(random, r -> {
+			final StochasticUniversalSelector<DoubleGene, Double> selector = factory().newInstance();
+			final ISeq<Phenotype<DoubleGene, Double>> selectedPop =
+				selector.select(population, population.size(), Optimize.MAXIMUM);
+			Assert.assertEquals(selectedPop.get(0).fitness(), 0.7);
+			Assert.assertEquals(selectedPop.get(1).fitness(), 0.7);
+			Assert.assertEquals(selectedPop.get(2).fitness(), 0.1);
+		});
 	}
 
 	@Test(


### PR DESCRIPTION
There are multiple issues that appear in the current version of the implementation:
1. Unnecessary sorting is done before each selection. SUS does not require sorting, copy and sort look like wasting of resources, can be critical on algorithms requiring highly intensive computation.
2. Distance between points in SUS must be equally sized intervals. The previous version had random size interval between zero's and first points.
3. Actual selection of population from points and cumulative probability had a bug. Selection of i-th element has been done through analyzing (i-1)-th interval. Previously, the 0-th element has always been skipped. As a result first interval actually always corresponded to the second element creating a skew in distribution.

For example, if we had probabilities == [0.7, 0.2, 0.1], and points == (0.12, 0.45, 0.78). It can be seen that these parameters will produce [1, 1, 2] population (values are indexes of parents from original populations). Obviously, it is wrong.

It ia also worth to mention, that this fix shows better results on performance tests done for SUS. Previous versions did fail some of the tests. This version actually passes all performance tests.